### PR TITLE
Fixes error where BASH is not set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EMACS = emacs
-SHELL = BASH
+SHELL := /bin/bash
 
 build: jsonian.elc
 


### PR DESCRIPTION
Previous implementation:
```
~/src/jsonian$ make build
emacs -Q --batch -L . -f batch-byte-compile jsonian.el
make: BASH: No such file or directory
make: *** [Makefile:18: jsonian.elc] Error 127
```

This branch:
```
~/src/jsonian$ make clean
rm jsonian.elc
~/src/jsonian$ grep SHELL Makefile
SHELL := /bin/bash
~/src/jsonian$ make build
emacs -Q --batch -L . -f batch-byte-compile jsonian.el
```

Signed-off-by: Ashton Von Honnecke <ashton@pixelstub.com>