### PR TITLE
Add a space to the beginning of the edit-string mode lighter

### DIFF
--- a/jsonian.el
+++ b/jsonian.el
@@ -538,7 +538,7 @@ This means replacing '\\n' with '\n' and '\\t' with '\t'."
 This mode is used to setup editing functions for strings at point.
 It should *not* be toggled manually."
   :global nil
-  :lighter "edit-string"
+  :lighter " edit-string"
   :keymap (list
            (cons (kbd "C-c C-c") #'jsonian-edit-mode-return)
            (cons (kbd "C-c C-k") #'jsonian-edit-mode-cancel)))


### PR DESCRIPTION
Lighters for minor modes seem to require a space at the beginning [(example)](https://github.com/emacs-mirror/emacs/blob/c1829b307cffce046bec6fcbdff03dbab9f4b562/lisp/simple.el#L8267), or the modeline will look like `Fundamentaledit-string`.