### PR TITLE
Correct indent for empty lines

### DIFF
--- a/jsonian-tests.el
+++ b/jsonian-tests.el
@@ -223,5 +223,12 @@ Specifically, we need to comply with what `completion-boundaries' describes."
              (jsonian--find-children)
              '((1 . 58) (0 . 35))))))
 
+(ert-deftest jsonian-indent-line ()
+  (with-file-and-point "path1" 107
+    (jsonian-mode)
+    (insert ",")
+    (funcall-interactively #'newline-and-indent)
+    (should (= (point) 111))))
+
 (provide 'jsonian-tests)
 ;;; jsonian-tests.el ends here

--- a/jsonian.el
+++ b/jsonian.el
@@ -1256,7 +1256,16 @@ number of spaces is determined by
       ;; Make sure that we account for any closing brackets in front of (point)
       (save-excursion
         (beginning-of-line)
-        (jsonian--forward-whitespace)
+        ;; We want to be careful here that we only look at this line, and not
+        ;; the next line. Looking at the next line will cause us to go backward
+        ;; when looking at line 2 of the following:
+        ;; 1: {
+        ;; 2:
+        ;; 3: }
+        (while (and (char-after)
+                    (= (char-after) ? )
+                    (= (char-after) ?\t))
+          (forward-char))
         (when (or (eq (char-after) ?\})
                   (eq (char-after) ?\]))
           (cl-decf level jsonian-spaces-per-indentation)))


### PR DESCRIPTION
We previously errored for basic scenarios like:
```json
{

}
```

This was because we considered the `}` in discovering the indent, even though it is not part of the line we were evaluating. This is addressed and a test is added to prevent regressions. 