### PR TITLE
Fix lisp nesting in `jsonian-no-so-long-mode`

### DIFF
--- a/jsonian.el
+++ b/jsonian.el
@@ -1402,9 +1402,15 @@ designed to be installed with `advice-add' and `:before-until'."
       (jsonian-narrow-to-defun arg))
     correct))
 
+(defvar jsonian--so-long-predicate nil
+  "The function originally assigned to `so-long-predicate'.")
+
 (defun jsonian-unload-function ()
   "Unload `jsonian'."
-  (advice-remove #'narrow-to-defun #'jsonian--correct-narrow-to-defun))
+  (advice-remove #'narrow-to-defun #'jsonian--correct-narrow-to-defun)
+  (defvar so-long-predicate)
+  (when jsonian--so-long-predicate
+    (setq so-long-predicate jsonian--so-long-predicate)))
 
 
 ;; Foreign integration
@@ -1432,10 +1438,11 @@ designed to be installed with `advice-add' and `:before-until'."
   (unless (boundp 'so-long-predicate)
     (user-error "`so-long' mode needs to be loaded"))
   (defvar so-long-predicate)
+  (setq jsonian--so-long-predicate so-long-predicate)
   (setq so-long-predicate
         (lambda ()
           (unless (eq major-mode 'jsonian-mode)
-            (funcall so-long-predicate)))))
+            (funcall jsonian--so-long-predicate)))))
 
 
 ;; Miscellaneous utility functions


### PR DESCRIPTION
Adds new variable `jsonian--so-long-predicate` that stores the original function stored in `so-long-predicate` before setting it to a lambda (which now calls the stored old function).

Calling `jsonian-unload-function` reinstates the old function.

The original implementation leads to "Lisp nesting exceeds max-lisp-eval-depth" on every call to the predicate function.

