### PR TITLE
Parse "null"s forward

### DIFF
--- a/jsonian-tests.el
+++ b/jsonian-tests.el
@@ -204,6 +204,14 @@ We test that all lines are unchanged"
              '("b")))
     (should (= (point) (point-min)))))
 
+(ert-deftest jsonian-find-with-null ()
+  "Test that we can use `jsonian-find' with null values.
+This is different then `jsonian-path-with-null' because it tests
+cached descent, instead of ascent."
+  (with-file-and-point "path-with-null.json" (point-min)
+    (should (= (jsonian-find ".b") 18))
+    (should (= (jsonian-find ".a") 5))))
+
 (ert-deftest jsonian-simple-segment ()
   "Check that we correctly identify simple segments."
   (mapc

--- a/jsonian.el
+++ b/jsonian.el
@@ -723,6 +723,7 @@ PROPERTY defaults to `face'."
        ((eq (char-after) ?:) (forward-char))
        ((eq (char-after) ?t) (jsonian--forward-true))
        ((eq (char-after) ?f) (jsonian--forward-false))
+       ((eq (char-after) ?n) (jsonian--forward-null))
        ((eq (char-after) ?\{) (forward-list))
        ((eq (char-after) ?\[) (forward-list))
        ((and (char-after) (>= (char-after) ?0) (<= (char-after) ?9)) (jsonian--forward-number))
@@ -1041,11 +1042,9 @@ TYPE is a flag specifying the type of completion."
      ((eq (car-safe type) 'boundaries)
       (cons 'boundaries (jsonian--completing-boundary str (cdr type))))
      ((eq type 'metadata)
-      (cons 'metadata (list
-                       (cons 'display-sort-function
-                             (apply-partially #'jsonian--completing-sort str))
-                       (cons 'affixation-function
-                             (apply-partially #'jsonian--completing-affixation str jsonian--cache)))))
+      (cons 'metadata `((display-sort-function . ,(apply-partially #'jsonian--completing-sort str))
+                       (affixation-function .
+                             ,(apply-partially #'jsonian--completing-affixation str jsonian--cache)))))
      (t (error "Unexpected type `%s'" type)))))
 
 (defun jsonian--completing-affixation (prefix cache paths)
@@ -1213,24 +1212,24 @@ is returned."
 (defun jsonian--node-preview (pos)
   "Provide a preview of the value of the node at POS."
   (cond
-((eq (char-after pos) ?\")
+   ((eq (char-after pos) ?\")
     ;; TODO: bound size of string
     (save-excursion
       (goto-char pos)
       (if-let (end (jsonian--pos-in-keyp t))
           (progn (goto-char end)
-                          (jsonian--forward-to-significant-char)
-                          (forward-char)
-                          (jsonian--forward-to-significant-char)
-                          (jsonian--node-preview (point)))
+                 (jsonian--forward-to-significant-char)
+                 (forward-char)
+                 (jsonian--forward-to-significant-char)
+                 (jsonian--node-preview (point)))
         (jsonian--forward-string)
         (buffer-substring pos (point)))))
-   ((or (eq (char-after pos) ?t)
-        (eq (char-after pos) ?n))
+   ((or (eq (char-after pos) ?t)  ; literal: true
+        (eq (char-after pos) ?n)) ; literal: null
     (buffer-substring pos (+ pos 4)))
-   ((eq (char-after pos) ?f)
+   ((eq (char-after pos) ?f)      ; literal: false
     (buffer-substring pos (+ pos 5)))
-   ((and (<= (char-after pos) ?9)
+   ((and (<= (char-after pos) ?9) ; number
          (>= (char-after pos) ?0))
     (buffer-substring pos (save-excursion
                             (goto-char pos)
@@ -1643,10 +1642,11 @@ DIRECTION indicates if parsing is forward (:forward) or backward (:backward)."
   "The public jsonian- function that directly encloses the current stack frame."
   ;; i=3 gets us to the function that called `jsonian--enclosing-public-frame'.
   (let* ((i 3) (frame (backtrace-frame i))
+         (disp (lambda (x) (if (symbolp x) (symbol-name x) (format "%s" x))))
          ;; We take that function as a backup value
-         (ret-val (symbol-name (nth 1 frame))))
+         (ret-val (funcall disp (nth 1 frame))))
     (while frame
-      (let ((fn-name (symbol-name (nth 1 frame))))
+      (let ((fn-name (funcall disp (nth 1 frame))))
         (if (and (string-prefix-p "jsonian-" fn-name)
                  (not (string-prefix-p "jsonian--" fn-name)))
             (setq ret-val fn-name


### PR DESCRIPTION
While `jsonian-path` didn't have any issues with `null` literals being parsed. `jsonian-find` didn't handle them correctly. 

This PR fixes that by adding parsing for `null` literals when parsing down.

---

It also fixes the indentation in `jsonian--node-preview`. 