### PR TITLE
Cache `jsonian-path`

### DIFF
--- a/jsonian-tests.el
+++ b/jsonian-tests.el
@@ -340,5 +340,18 @@ Specifically, we need to comply with what `completion-boundaries' describes."
   (with-file-and-point "compact1.json" 91
     (should (equal (jsonian-path) '(1 "abc" 1 1 "final")))))
 
+(ert-deftest jsonian-cache-match ()
+  "Check that `jsonian-path' and `jsonian-find' have matching cache keys."
+  (with-file-and-point "path1.json" 1
+    (should (equal (jsonian-find "fizz[4].some") 66))
+    (forward-char)
+    (let ((path-size (hash-table-count (jsonian--cache-paths jsonian--cache)))
+          (location-size (hash-table-count (jsonian--cache-locations jsonian--cache))))
+      (should (equal (jsonian-path) '("fizz" 4 "some")))
+      (should (equal path-size
+                     (hash-table-count (jsonian--cache-paths jsonian--cache))))
+      (should (equal location-size
+                     (hash-table-count (jsonian--cache-locations jsonian--cache)))))))
+
 (provide 'jsonian-tests)
 ;;; jsonian-tests.el ends here


### PR DESCRIPTION
`jsonian-find` updates and references a cache of node location during operation. This is necessary, since `jsonian-find` recalculates on each keypress. `jsonian-path` only does some of the work that `jsonian-find` does, but it can still benefit from the same cache. This PR does N things:

1. It augments the cache to allow `location -> path` lookup, where previously only `path -> location` lookup was possible.
2. It introduces `jsonian--cached-path` to take advantage of this new cache capability.