### PR TITLE
Replace font-lock with low-level implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,5 +79,8 @@ bench-javascript: bench-base
 bench-fundamental: bench-base
 	$(call bench,${LARGE_JSON_FILE},"(fundamental-mode)",)
 
+bench-fundamental-keyword-only: bench-base
+	$(call bench,${LARGE_JSON_FILE},"(progn (fundamental-mode) (setq-local font-lock-defaults '(() t)))",)
+
 bench-prog: bench-base
 	$(call bench,${LARGE_JSON_FILE},"(prog-mode)",)


### PR DESCRIPTION
The fontification logic is changed from a syntax table based to a text based implementation.

Benchmarks:

`bench-jsonian` on the `main` branch: 8.572s
`bench-jsonian` on the new branch: 4.204s
`bench-prog`: 5.794s
`bench-fundamental`: 5.862s
`bench-fundamental-keyword-only`: 0.105s

When `font-lock-keywords-only` is nil, `font-lock-fontify-region` took more than 5 seconds even in the fundamental mode.  If it is non-nil, `font-lock-fontify-region` is instantaneous.


Drawbacks:

- Since fontification doesn't trigger `syntax-ppss`, some functions like `forward-sexp` or `end-of-line` took a fraction of a second (e.g. 0.37s) for the first time.
- It adds 157 lines of code and complicates `jsonian`.
- It may contain bugs (I hope not).


Bonus:

- Highlighting of escape sequences.  "This\nmakes\nstrings\nlike\nthis\neasier\nto\nread."


Discussion:

Does this offer real benefit?  Emacs' font locking is smart enough to fontify only a fraction of the buffer, so opening a large file or moving to the end of the buffer is instantaneous (unless the contents of the file is a single long line).  Can we justify a long and complex implementation?
